### PR TITLE
fix: :bug: Set the backgroundSize value to "auto" for NativeImageBackground

### DIFF
--- a/package/nativeComponents/layouts/NativeImageBackground.js
+++ b/package/nativeComponents/layouts/NativeImageBackground.js
@@ -3,7 +3,7 @@ import {SCImageBackground} from '../../styledComponents/layouts/SCImageBackgroun
 import { UTurnLeft } from '@mui/icons-material';
 
 export default function NativeImageBackground(props) {
-  const {source, resizeMode} = props;
+  const {source, resizeMode="auto"} = props;
 
   return (
     <SCImageBackground


### PR DESCRIPTION
Set the backgroundSize value to "auto" for NativeImageBackground so that images can be stretched by default

ref #20