### PR TITLE
feat(core): :zap: displayIcon prop for Core Menu

### DIFF
--- a/package/helper/menuUtil.js
+++ b/package/helper/menuUtil.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 // eslint-disable-next-line no-unused-vars, unused-imports/no-unused-imports
 import React from "react";
 
@@ -67,7 +68,8 @@ export default function getNativeMenuItem(
   locationPathname,
   theme,
   allTypes,
-  routeRegistry
+  routeRegistry,
+  displayIcon
 ) {
   /**
    * @todo review required for using core menu item instead of core List Item
@@ -75,6 +77,7 @@ export default function getNativeMenuItem(
   return menuItem.type === allTypes?.MENU_SEPERATOR ? (
     <NativeDivider />
   ) : open ? (
+    
     <NativeLink href={getLink(menuItem, allTypes, routeRegistry)}>
       <NativeMenuItem
         sx={{
@@ -87,49 +90,52 @@ export default function getNativeMenuItem(
         }}
         key={menuItem.id}
         disablePadding
-        title={menuItem.label}
+        title={menuItem?.label}
         onClick={() => {
           OnMenuClick(menuItem);
         }}
       >
-        <NativeListItemIcon
-          styleClasses={[StyledComponentsClasses.MENU.LIST_ITEM_ICON, ...getTypeWiseStyle(menuItem, allTypes?.MENU_ITEM_ICON, allTypes)]}
-        >
-          {/* @todo may have to correct this */}
-          <NativeIcon
-            name={
-              typeof menuItem?.icon === "object"
-                ? menuItem?.icon?.icon
-                : typeof menuItem?.icon === "string" && isJson(menuItem?.icon)
-                  ? JSON.parse(menuItem?.icon)?.icon
-                  : menuItem?.icon
-            }
-            type={
-              typeof menuItem?.icon === "object"
-                ? menuItem?.icon?.type || "material-icons"
-                : typeof menuItem?.icon === "string" && isJson(menuItem?.icon)
-                  ? JSON.parse(menuItem?.icon)?.type
-                  : "material-icons"
-            }
-            childrenFlag={
-              typeof menuItem?.icon === "object"
-                ? menuItem?.icon?.type == "material-icons" ||
+        {displayIcon ?
+          (<NativeListItemIcon
+            styleClasses={[StyledComponentsClasses.MENU.LIST_ITEM_ICON, ...getTypeWiseStyle(menuItem, allTypes?.MENU_ITEM_ICON, allTypes)]}
+          >
+            {/* @todo may have to correct this */}
+            <NativeIcon
+              name={
+                typeof menuItem?.icon === "object"
+                  ? menuItem?.icon?.icon
+                  : typeof menuItem?.icon === "string" && isJson(menuItem?.icon)
+                    ? JSON.parse(menuItem?.icon)?.icon
+                    : menuItem?.icon
+              }
+              type={
+                typeof menuItem?.icon === "object"
+                  ? menuItem?.icon?.type || "material-icons"
+                  : typeof menuItem?.icon === "string" && isJson(menuItem?.icon)
+                    ? JSON.parse(menuItem?.icon)?.type
+                    : "material-icons"
+              }
+              childrenFlag={
+                typeof menuItem?.icon === "object"
+                  ? menuItem?.icon?.type == "material-icons" ||
                   menuItem?.icon?.type == "material-icons-outlined"
-                : typeof menuItem?.icon === "string" && isJson(menuItem?.icon)
-                  ? JSON.parse(menuItem?.icon)?.type == "material-icons" ||
+                  : typeof menuItem?.icon === "string" && isJson(menuItem?.icon)
+                    ? JSON.parse(menuItem?.icon)?.type == "material-icons" ||
                   JSON.parse(menuItem?.icon)?.type == "material-icons-outlined"
-                  : true
-            }
-            sx={{
-              color: `${
-                menuItem?.type === allTypes?.MENU_ITEM &&
+                    : true
+              }
+              sx={{
+                color: `${
+                  menuItem?.type === allTypes?.MENU_ITEM &&
                 locationPathname === menuItem?.link
-                  ? theme?.palette?.primary?.light
-                  : theme?.palette?.secondary?.dark
-              }!important`,
-            }}
-          />
-        </NativeListItemIcon>
+                    ? theme?.palette?.primary?.light
+                    : theme?.palette?.secondary?.dark
+                }!important`,
+              }}
+            />
+          </NativeListItemIcon>) :
+
+          (<></>)}
 
         <NativeListItemText
           disableTypography
@@ -155,7 +161,8 @@ export default function getNativeMenuItem(
           : "javascript:void(0)"
       }
     >
-      <NativeIconButton
+     
+        (<NativeIconButton
         title={menuItem?.label}
         titlePlacement={"right"}
         onClick={() => {
@@ -163,6 +170,7 @@ export default function getNativeMenuItem(
           OnMenuClick(menuItem);
         }}
       >
+             
         <NativeIcon
           name={
             typeof menuItem?.icon === "object"
@@ -195,13 +203,15 @@ export default function getNativeMenuItem(
                 : theme?.palette?.secondary?.dark
             }!important`,
           }}
-        ></NativeIcon>
+        ></NativeIcon> 
+        
       </NativeIconButton>
     </NativeLink>
   );
 }
 
 function getTypeWiseStyle(item, elemType, allTypes) {
+  
   let styles = [];
   const {
     MENU_PARENT_ITEM,


### PR DESCRIPTION
## Description

For Core Menu Items, display the Image Icon based on display icon prop flag. Also updated the tooltip of the components menu.
##Current Issue
WRPD-enhancement:icondisplayMenu #64 
## Related Issues
1)WRPD-enhancement:icondisplayMenu #218
2)enhancement: icondisplayMenu #146
<!--List any related issues that this pull request addresses. -->

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [x] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [x] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [x] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->
![image](https://github.com/wrappid/guide-module/assets/79081578/ad96a52c-bbc4-4d69-8307-cc3c10e3097b)


## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers
[techoneel](https://github.com/techoneel)
<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
