### PR TITLE
feat(global): :sparkles: pass dialogProps in SCDialog

### DIFF
--- a/package/nativeComponents/feedback/NativeDialog.js
+++ b/package/nativeComponents/feedback/NativeDialog.js
@@ -40,6 +40,7 @@ export default function NativeDialog(props) {
             minWidth : "20%",
           }
         }}
+        { ...dialog?.dialogProps}
       >
         {dialog?.type === "info" ? (
           <NativeBox


### PR DESCRIPTION
## Description
pass dialogProps in SCDialog, so we can pass dialogProps as object in setDialog' sJSON

## Related Issues
Ref: #105

