### PR TITLE
feat(global): :sparkles: passing prop in LinearProgress

### DIFF
--- a/package/nativeComponents/feedback/NativeLinearProgress.js
+++ b/package/nativeComponents/feedback/NativeLinearProgress.js
@@ -1,8 +1,32 @@
 // eslint-disable-next-line no-unused-vars, unused-imports/no-unused-imports
 import React from "react";
 
+// eslint-disable-next-line import/no-unresolved
+import { UtilityClasses } from "@wrappid/styles";
+
 import { SCLinearProgress } from "../../styledComponents/feedback/SCLinearProgress";
+import NativeTypography from "../dataDisplay/NativeTypography";
+import NativeBox from "../layouts/NativeBox";
 
 export default function NativeLinearProgress(props) {
-  return <SCLinearProgress {...props}>{props.children}</SCLinearProgress>;
+  const { children, showPercentage, ...rest } = props;
+  const boxWidth = "35px";
+
+  return (
+    <NativeBox styleClasses={[UtilityClasses.DISPLAY.FLEX, UtilityClasses.ALIGNMENT.ALIGN_ITEMS_CENTER]}>
+      <NativeBox styleClasses={[UtilityClasses.WIDTH.W_100]}>
+        <SCLinearProgress {...rest}>{children}</SCLinearProgress>
+      </NativeBox>
+      
+      {showPercentage && (
+        <NativeBox width={boxWidth} styleClasses={[UtilityClasses.MARGIN.ML1]}>
+          <NativeTypography variant="body1">
+            {`${Math.round(rest.value)}%`}
+          </NativeTypography>
+        </NativeBox>
+      )}
+      
+    </NativeBox>
+
+  );
 }

--- a/package/nativeComponents/feedback/NativeLinearProgress.js
+++ b/package/nativeComponents/feedback/NativeLinearProgress.js
@@ -9,24 +9,23 @@ import NativeTypography from "../dataDisplay/NativeTypography";
 import NativeBox from "../layouts/NativeBox";
 
 export default function NativeLinearProgress(props) {
-  const { children, showPercentage, ...rest } = props;
-  const boxWidth = "35px";
+  const { showLabel, ...restProps } = props;
 
-  return (
-    <NativeBox styleClasses={[UtilityClasses.DISPLAY.FLEX, UtilityClasses.ALIGNMENT.ALIGN_ITEMS_CENTER]}>
-      <NativeBox styleClasses={[UtilityClasses.WIDTH.W_100]}>
-        <SCLinearProgress {...rest}>{children}</SCLinearProgress>
-      </NativeBox>
-      
-      {showPercentage && (
-        <NativeBox width={boxWidth} styleClasses={[UtilityClasses.MARGIN.ML1]}>
-          <NativeTypography variant="body1">
-            {`${Math.round(rest.value)}%`}
+  if (!showLabel) {
+    return <SCLinearProgress {...restProps} />;
+  } else {
+    return (
+      <NativeBox styleClasses={[UtilityClasses.DISPLAY.FLEX, UtilityClasses.ALIGNMENT.ALIGN_ITEMS_CENTER]}>
+        <NativeBox styleClasses={[UtilityClasses.WIDTH.W_100]}>
+          <SCLinearProgress {...restProps} />
+        </NativeBox>
+
+        <NativeBox width={restProps.labelWidth} styleClasses={[UtilityClasses.MARGIN.ML1]}>
+          <NativeTypography>
+            {`${Math.round(restProps.value)}%`}
           </NativeTypography>
         </NativeBox>
-      )}
-      
-    </NativeBox>
-
-  );
+      </NativeBox>
+    );
+  }
 }


### PR DESCRIPTION
## Description
I updated the code, where pass two props (showLabel, labelWidth), if the showLabel prop is passed as true then a label is displayed along with the LinearProgressbar. Also, the labelWidth prop is responsible for label width which is by default 35px, also users can change this width as they need by passing a value in the labelWidth prop. 
Ref: https://github.com/wrappid/native-web/issues/114

## Related Issues

https://github.com/wrappid/core/issues/332 

## Testing
I pass those props in the code of this(CoreLinearProgress.docs.js) file, and the code works properly.  

## Checklist

- [X] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [X] My code follows the project's style guidelines and best practices.
- [X] I have updated the documentation if necessary.
- [X] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts in my branch.

## Screenshots (if applicable)

## Additional Notes

## Reviewers

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?


