### PR TITLE
fix(global): :bug: update NativeAppBar code

### DIFF
--- a/package/nativeComponents/surfaces/NativeAppBar.js
+++ b/package/nativeComponents/surfaces/NativeAppBar.js
@@ -8,8 +8,8 @@ export default function NativeAppBar(props) {
   const { auth } = props;
 
   return (
-    <SCAppBar {...props} position="fixed">
-      {props.children}
+    <SCAppBar {...props}>
+      {props?.children}
     </SCAppBar>
   );
 }

--- a/package/nativeComponents/surfaces/NativeAppBar.js
+++ b/package/nativeComponents/surfaces/NativeAppBar.js
@@ -4,12 +4,8 @@ import React from "react";
 import { SCAppBar } from "../../styledComponents/surfaces/SCAppBar";
 
 export default function NativeAppBar(props) {
-  // eslint-disable-next-line no-unused-vars
-  const { auth } = props;
 
   return (
-    <SCAppBar {...props}>
-      {props?.children}
-    </SCAppBar>
+    <SCAppBar {...props} />
   );
 }


### PR DESCRIPTION
## Description

Here position is written in hardcoded, which is not needed, we can pass the position in prop. So I updated this, Also one of the reasons behind the updation is this position: fixed effects in CoreSnackbar.docs.js

Ref: #121

## Related Issues

https://github.com/wrappid/guide-module/issues/252

## Testing
I use CoreAppBar in CoreSnackbar.docs.js, this works properly.

## Checklist

- [X] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [X] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)

## Additional Notes

## Reviewers

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
