### PR TITLE
fix(global): :bug: fix miniDrawer is not visible

### DIFF
--- a/package/styledComponents/navigation/SCDrawer.js
+++ b/package/styledComponents/navigation/SCDrawer.js
@@ -27,7 +27,7 @@ const closedMixin = (config, theme) => ({
     easing  : theme.transitions.easing.sharp,
   }),
   width                       : 0,
-  [theme.breakpoints.up("sm")]: { width: config?.miniDrawerWidth || DEFAULT_MINI_DRAWER_WIDTH },
+  [theme.breakpoints.up("sm")]: { width: `${config?.miniDrawerWidth || DEFAULT_MINI_DRAWER_WIDTH}px` },
 });
 
 export const SCDrawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== "open" })(({ config, open, theme }) => ({


### PR DESCRIPTION


## Description

miniDrawer is not visible as px is not defined, which is in SCDrawer.js
Ref: #132

## Related Issues

## Testing

## Checklist

- [X] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [X] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)

## Additional Notes

## Reviewers

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
