### PR TITLE
feat(global): :sparkles: nativelist sub components comes in a grid format

### DIFF
--- a/package/nativeComponents/layouts/NativeList.js
+++ b/package/nativeComponents/layouts/NativeList.js
@@ -9,7 +9,9 @@ import { SCList } from "../../styledComponents/layouts/SCList";
 export default function NativeList(props) {
 
   const { children, ...restProps } = props;
-  const [gridProps, setGridProps] = React.useState({ gridSize: { md: Number(props.gridItemComponent) } });
+  const [gridProps, setGridProps] = React.useState({});
+
+  React.useEffect(() => { setGridProps({ gridSize: { md: Number(props.gridItemComponent) } }); }, []);
   const listStyleClasses = () => {
     let styleClasses = [];
       

--- a/package/nativeComponents/layouts/NativeList.js
+++ b/package/nativeComponents/layouts/NativeList.js
@@ -3,15 +3,16 @@ import React from "react";
 // eslint-disable-next-line import/no-unresolved
 import { UtilityClasses } from "@wrappid/styles";
 
+import NativeGrid from "./NativeGrid";
 import { SCList } from "../../styledComponents/layouts/SCList";
 
 export default function NativeList(props) {
 
   const { children, ...restProps } = props;
-
+  const [gridProps, setGridProps] = React.useState({ gridSize: { md: Number(props.gridItemComponent) } });
   const listStyleClasses = () => {
     let styleClasses = [];
-
+      
     if (props.variant == "HTML") {
       if (props.listType) {
         styleClasses.push(UtilityClasses.PADDING.PL5, UtilityClasses.LIST_STYLE[props.listType]);
@@ -19,29 +20,73 @@ export default function NativeList(props) {
     }
     return [...styleClasses, ...(props?.styleClasses || [])];
   };
+
   const listItemStyleClasses = (childProps) => {
     let styleClasses = [];
-
+      
     if (props.listType) {
-      styleClasses.push(UtilityClasses.DISPLAY.LIST_ITEM, UtilityClasses.PADDING.P0);
+      styleClasses.push(UtilityClasses.DISPLAY.LIST_ITEM, UtilityClasses.PADDING.P0, UtilityClasses.BORDER.BORDER);
     }
     return [...styleClasses, ...(childProps?.styleClasses || [])];
   };
 
-  return <SCList
-    styleClasses={listStyleClasses()}
-    {...restProps}>{
-      React.Children.map(children, child => {
-        if (React.isValidElement(child)) {
-          const updatedProps = {
-            ...child.props, // Spread existing props
-            styleClasses: listItemStyleClasses(child.props)
-          };
-
-          return React.cloneElement(child, updatedProps); // Pass both props
-        } else {
-          return child;
-        }
-      })}</SCList>;
+  if (props.variant == "GRID") {
+    if (props.gridItemComponent) {
+      return <SCList
+        styleClasses={listStyleClasses()}
+        {...restProps}>
+        <NativeGrid>{
+          React.Children.map(children, child => {
+            if (React.isValidElement(child)) {
+              const updatedProps = {
+                ...child.props,
+                gridProps   : gridProps,
+                styleClasses: listItemStyleClasses(child.props)
+              };
+        
+              return React.cloneElement(child, updatedProps); // Pass both props
+            } else {
+              return child;
+            }
+          })}</NativeGrid>
+      </SCList>;
+    } else {
+      return <SCList
+        styleClasses={listStyleClasses()}
+        {...restProps}>
+        <NativeGrid>{
+          React.Children.map(children, child => {
+            if (React.isValidElement(child)) {
+              const updatedProps = {
+                ...child.props,
+                styleClasses: listItemStyleClasses(child.props)
+              };
+        
+              return React.cloneElement(child, updatedProps); // Pass both props
+            } else {
+              return child;
+            }
+          })}</NativeGrid>
+      </SCList>;
+    }
+  }
+  else {
+  
+    return <SCList
+      styleClasses={listStyleClasses()}
+      {...restProps}>{
+        React.Children.map(children, child => {
+          if (React.isValidElement(child)) {
+            const updatedProps = {
+              ...child.props, // Spread existing props
+              styleClasses: listItemStyleClasses(child.props)
+            };
+        
+            return React.cloneElement(child, updatedProps); // Pass both props
+          } else {
+            return child;
+          }
+        })}</SCList>;
+  }
 }
-
+  


### PR DESCRIPTION
## Description
two new props has been introduced in corelist that can show the corelistitem in grid format an a prop that show how many section it can be divided

Ref: #136

## Related Issues

<!--List any related issues that this pull request addresses. -->

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [ ] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [ ] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
