### PR TITLE
fix(global): :bug: fix full width of toolbox component

### DIFF
--- a/package/nativeComponents/surfaces/NativeToolBox.js
+++ b/package/nativeComponents/surfaces/NativeToolBox.js
@@ -179,7 +179,7 @@ export default function NativeToolBox({
         height: expanded ? "auto" : dimensions.height || "auto",
         left  : `${position.left}px`, 
         top   : `${position.top}px`,
-        width : expanded ? "auto" : dimensions.width || "auto",
+        width : expanded ? "100%" : dimensions.width || "100%",
       }}
       styleClasses={[  
         // UtilityClasses.POSITION.POSITION_ABSOLUTE,
@@ -193,7 +193,7 @@ export default function NativeToolBox({
           UtilityClasses.ALIGNMENT.ALIGN_ITEMS_CENTER,
           UtilityClasses.BORDER.BORDER_BOTTOM,
           UtilityClasses.BORDER.BORDER_COLOR_GREY_400,
-          UtilityClasses.BG.BG_GREY_100
+          UtilityClasses.BG.BG_GREY_100,
         ]}
         onMouseDown={onMouseDownHeader}
       >
@@ -220,7 +220,7 @@ export default function NativeToolBox({
         timeout="auto"
         unmountOnExit
         styleClasses={[UtilityClasses.FLEX.FLEX_GROW_1, UtilityClasses.OVERFLOW.OVERFLOW_AUTO]}>
-        <NativeCardContent>
+        <NativeCardContent styleClasses={[UtilityClasses.PADDING.P0]}>
           {props.children}
         </NativeCardContent>
       </NativeCollapse>


### PR DESCRIPTION
## Description
Now, the toolbox component displays 100% width.

## Related Issues
Ref #139

## Testing
I have tested this in the app builder module, this code works fine.

## Checklist

- [x] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [x] I have resolved any merge conflicts in my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
