### PR TITLE
fix(global): :bug: browser autofill suggestion background and text color change

### DIFF
--- a/package/nativeComponents/inputs/NativeInput.js
+++ b/package/nativeComponents/inputs/NativeInput.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-unused-vars, unused-imports/no-unused-imports
 import React from "react";
 
 import { useTheme } from "@mui/material";
@@ -11,9 +10,11 @@ import { SCInput } from "../../styledComponents/inputs/SCInput";
 export default function NativeInput(props) {
   const { NativeId = getUUID() } = props;
   const theme = useTheme();
-  const defStyle = {};
+  
+  const defStyle = { transition: "color 5000s ease-in-out 0s, background-color 5000s ease-in-out 0s" }; /* This stops browser autofill suggestions from changing the background and text color in input field. Also I think that's a bad fix which needs to improve in future. */
 
   const [inputText, setInputText] = React.useState(props?.value || null);
+
   const onChange = (event) => {
     props?.onChange && props.onChange(event);
     setInputText(event?.target?.value);
@@ -22,10 +23,7 @@ export default function NativeInput(props) {
   return (
     <NativeFormControl variant={props?.variant || "standard"} NativeId={`Native-formControl-${NativeId}`}>
       <NativeInputLabel
-        // shrink={true}
-        error={
-          props.touched && props.error && props.error.length > 0 ? true : false
-        }
+        error={props.touched && props.error && props.error.length > 0}
         htmlFor={props.id}
       >
         {props.label}
@@ -48,7 +46,10 @@ export default function NativeInput(props) {
         min={props.min}
         readOnly={props.readOnly}
         onBlur={props?.formik?.handleBlur}
-        inputProps={props.inputProps ? { ...props.inputProps, style: defStyle } : { style: defStyle }}
+        inputProps={{
+          ...props.inputProps,
+          style: { ...defStyle },
+        }}
         endAdornment={props.endAdornment ? props.endAdornment : null}
         multiline={props.multiline ? props.multiline : false}
         rows={props.rows}


### PR DESCRIPTION
## Description
In the input field, if a browser suggestion appears and a selection is made from the dropdown, the background colour of the input field content changes along with the text colour. I fixed this problem.

## Related Issues
Ref #165

## Testing
<!-- Describe the testing steps you have taken to ensure that your changes work as expected -->

## Checklist

- [X] I have performed a thorough self-review of my code.
- [ ] I have added or updated relevant tests for my changes.
- [ ] My code follows the project's style guidelines and best practices.
- [ ] I have updated the documentation if necessary.
- [ ] I have added or updated relevant comments in my code.
- [X] I have resolved any merge conflicts of my branch.


## Screenshots (if applicable)
<!-- Include screenshots or animated GIFs to visually demonstrate the changes, if applicable -->

## Additional Notes

<!--Feel free to add any other relevant information that might be helpful to reviewers.-->

## Reviewers

<!--Tag any specific individuals or teams you'd like to review this pull request.

Thank you for your contribution!-->

---

## Maintainer Notes

- [ ] Has this change been tested in a staging environment?
- [ ] Does this change introduce any breaking changes or deprecations?
